### PR TITLE
Mutex should be ~Copyable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
 
   linux_swift_6_1:
     runs-on: ubuntu-latest
-    container: swift:6.1
+    container: swift:6.1.2
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -123,7 +123,7 @@ jobs:
 
   linux_swift_6_1_musl:
     runs-on: ubuntu-latest
-    container: swift:6.1
+    container: swift:6.1.2
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -146,7 +146,7 @@ jobs:
       - name: Install Swift
         uses: SwiftyLab/setup-swift@latest
         with:
-          swift-version: "6.1.0"
+          swift-version: "6.1.2"
       - name: Version
         run: swift --version
       - name: Build

--- a/Sources/AllocatedLock.swift
+++ b/Sources/AllocatedLock.swift
@@ -30,6 +30,7 @@
 //
 
 // Backports the Swift interface around OSAllocatedUnfairLock available in recent Darwin platforms
+@available(*, deprecated, message: "Unused by Mutex and will be removed in future versions.")
 public struct AllocatedLock<State>: @unchecked Sendable {
 
     @usableFromInline

--- a/Sources/MutexSwift5.swift
+++ b/Sources/MutexSwift5.swift
@@ -1,9 +1,9 @@
 //
-//  Mutex.swift
+//  MutexSwift5.swift
 //  swift-mutex
 //
-//  Created by Simon Whitty on 07/09/2024.
-//  Copyright 2024 Simon Whitty
+//  Created by Simon Whitty on 03/06/2025.
+//  Copyright 2025 Simon Whitty
 //
 //  Distributed under the permissive MIT license
 //  Get the latest version from here:
@@ -29,70 +29,33 @@
 //  SOFTWARE.
 //
 
-#if compiler(>=6)
+#if compiler(<6.0)
 
-#if !canImport(WinSDK)
-
-// Backports the Swift 6 type Mutex<Value> to all Darwin platforms
-
-@available(macOS, introduced: 13.0, deprecated: 15.0, message: "use Mutex from Synchronization module")
-@available(iOS, introduced: 16.0, deprecated: 18.0, message: "use Mutex from Synchronization module")
-@available(tvOS, introduced: 18.0, deprecated: 15.0, message: "use Mutex from Synchronization module")
-@available(watchOS, introduced: 11.0, deprecated: 15.0, message: "use Mutex from Synchronization module")
-@available(visionOS, introduced: 2.0, deprecated: 15.0, message: "use Mutex from Synchronization module")
-public struct Mutex<Value: ~Copyable>: @unchecked Sendable, ~Copyable {
-    let storage: Storage<Value>
-
-    public init(_ initialValue: consuming sending Value) {
-        self.storage = Storage(initialValue)
-    }
-
-    public borrowing func withLock<Result, E: Error>(
-        _ body: (inout sending Value) throws(E) -> sending Result
-    ) throws(E) -> sending Result {
-        storage.lock()
-        defer { storage.unlock() }
-        return try body(&storage.value)
-    }
-
-    public borrowing func withLockIfAvailable<Result, E: Error>(
-        _ body: (inout sending Value) throws(E) -> sending Result
-    ) throws(E) -> sending Result? {
-        guard storage.tryLock() else { return nil }
-        defer { storage.unlock() }
-        return try body(&storage.value)
-    }
-}
-
-#else
-
-// Windows doesn't support ~Copyable yet
+// Backports the Swift 6 type Mutex<Value> to Swift 5
 
 public struct Mutex<Value>: @unchecked Sendable {
     let storage: Storage<Value>
 
-    public init(_ initialValue: consuming sending Value) {
+    public init(_ initialValue: Value) {
         self.storage = Storage(initialValue)
     }
 
-    public borrowing func withLock<Result, E: Error>(
-        _ body: (inout sending Value) throws(E) -> sending Result
-    ) throws(E) -> sending Result {
+    public borrowing func withLock<Result>(
+        _ body: (inout Value) throws -> Result
+    ) rethrows -> Result {
         storage.lock()
         defer { storage.unlock() }
         return try body(&storage.value)
     }
 
-    public borrowing func withLockIfAvailable<Result, E: Error>(
-        _ body: (inout sending Value) throws(E) -> sending Result
-    ) throws(E) -> sending Result? {
+    public borrowing func withLockIfAvailable<Result>(
+        _ body: (inout Value) throws -> Result
+    ) rethrows -> Result? {
         guard storage.tryLock() else { return nil }
         defer { storage.unlock() }
         return try body(&storage.value)
     }
 }
-
-#endif
 
 #if canImport(Darwin)
 
@@ -102,7 +65,7 @@ import func os.os_unfair_lock_lock
 import func os.os_unfair_lock_unlock
 import func os.os_unfair_lock_trylock
 
-final class Storage<Value: ~Copyable> {
+final class Storage<Value> {
     private let _lock: os_unfair_lock_t
     var value: Value
 
@@ -129,7 +92,6 @@ final class Storage<Value: ~Copyable> {
         self._lock.deallocate()
     }
 }
-
 #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
 
 #if canImport(Musl)
@@ -140,9 +102,8 @@ import Android
 import Glibc
 #endif
 
-final class Storage<Value: ~Copyable> {
+final class Storage<Value> {
     private let _lock: UnsafeMutablePointer<pthread_mutex_t>
-
     var value: Value
 
     init(_ initialValue: consuming Value) {
@@ -174,7 +135,6 @@ final class Storage<Value: ~Copyable> {
         self._lock.deallocate()
     }
 }
-
 #elseif canImport(WinSDK)
 
 import ucrt

--- a/Tests/MutexTests.swift
+++ b/Tests/MutexTests.swift
@@ -55,11 +55,11 @@ struct MutexTests {
     @Test
     func lockIfAvailable_ReturnsValue() {
         let mutex = Mutex("fish")
-        mutex.lock.unsafeLock()
+        mutex.unsafeLock()
         #expect(
             mutex.withLockIfAvailable { _ in "chips" } == nil
         )
-        mutex.lock.unsafeUnlock()
+        mutex.unsafeUnlock()
         #expect(
             mutex.withLockIfAvailable { _ in "chips" } == "chips"
         )
@@ -72,5 +72,10 @@ struct MutexTests {
             try mutex.withLockIfAvailable { _ -> Void in throw CancellationError() }
         }
     }
+}
+
+extension Mutex {
+    func unsafeLock() { storage.lock() }
+    func unsafeUnlock() { storage.unlock() }
 }
 #endif

--- a/Tests/MutexXCTests.swift
+++ b/Tests/MutexXCTests.swift
@@ -52,11 +52,11 @@ final class MutexTests: XCTestCase {
 
     func testLockIfAvailable_ReturnsValue() {
         let mutex = Mutex("fish")
-        mutex.lock.unsafeLock()
+        mutex.unsafeLock()
         XCTAssertNil(
             mutex.withLockIfAvailable { _ in "chips" }
         )
-        mutex.lock.unsafeUnlock()
+        mutex.unsafeUnlock()
         XCTAssertEqual(
             mutex.withLockIfAvailable { _ in "chips" },
             "chips"
@@ -69,5 +69,10 @@ final class MutexTests: XCTestCase {
             _ = $0 is CancellationError
         }
     }
+}
+
+extension Mutex {
+    func unsafeLock() { storage.lock() }
+    func unsafeUnlock() { storage.unlock() }
 }
 #endif


### PR DESCRIPTION
Updates `Mutex` to support non copyable's aligning with the Swift 6 API.

```swift
struct Mutex<Value: ~Copyable>: ~Copyable
```

Deprecates `AllocatedLock` as it is now longer used, instead a single `class` is used for the storage of both he value and lock.

> Note: The windows version does not yet support these `~Copyable` annotations.